### PR TITLE
rearrange set_decrypt_message logic to use set_shifts

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,4 +1,3 @@
-
 require 'date'
 
 class Enigma
@@ -32,10 +31,10 @@ class Enigma
   end
 
   def set_decrypt_message(message, key, date)
-    (0...message.length).step(4){|i| message[i] = get_a_shift(key, date)[alphabet_array.find_index(message[i])]}
-    (1...message.length).step(4){|i| message[i] = get_b_shift(key, date)[alphabet_array.find_index(message[i])]}
-    (2...message.length).step(4){|i| message[i] = get_c_shift(key, date)[alphabet_array.find_index(message[i])]}
-    (3...message.length).step(4){|i| message[i] = get_d_shift(key, date)[alphabet_array.find_index(message[i])]}
+    (0...message.length).step(4){|i| message[i] = alphabet_array[set_a_shift(key, date).find_index(message[i])]}
+    (1...message.length).step(4){|i| message[i] = alphabet_array[set_b_shift(key, date).find_index(message[i])]}
+    (2...message.length).step(4){|i| message[i] = alphabet_array[set_c_shift(key, date).find_index(message[i])]}
+    (3...message.length).step(4){|i| message[i] = alphabet_array[set_d_shift(key, date).find_index(message[i])]}
     message
   end
 
@@ -53,22 +52,10 @@ class Enigma
     alphabet_array.rotate(shift_key + offset_key)
   end
 
-  def get_a_shift(key, date)
-    shift_key = key[0..1].to_i
-    offset_key = last_four(date)[0].to_i
-    alphabet_array.rotate((-1)*(shift_key + offset_key))
-  end
-
   def set_b_shift(key, date)
     shift_key = key[1..2].to_i
     offset_key = last_four(date)[1].to_i
     alphabet_array.rotate(shift_key + offset_key)
-  end
-
-  def get_b_shift(key, date)
-    shift_key = key[1..2].to_i
-    offset_key = last_four(date)[1].to_i
-    alphabet_array.rotate((-1)*(shift_key + offset_key))
   end
 
   def set_c_shift(key, date)
@@ -77,21 +64,9 @@ class Enigma
     alphabet_array.rotate(shift_key + offset_key)
   end
 
-  def get_c_shift(key, date)
-    shift_key = key[2..3].to_i
-    offset_key = last_four(date)[2].to_i
-    alphabet_array.rotate((-1)*(shift_key + offset_key))
-  end
-
   def set_d_shift(key, date)
     shift_key = key[3..4].to_i
     offset_key = last_four(date)[3].to_i
     alphabet_array.rotate(shift_key + offset_key)
-  end
-
-  def get_d_shift(key, date)
-    shift_key = key[3..4].to_i
-    offset_key = last_four(date)[3].to_i
-    alphabet_array.rotate((-1)*(shift_key + offset_key))
   end
 end


### PR DESCRIPTION
What does this PR do?
--
Refactor `Enigma` class and rearrange `set_decrypt_message` method to use same logic as `set_encrypt_message` method. Delete all `get_shift` methods.